### PR TITLE
CplugHostContext changes

### DIFF
--- a/example/config.h
+++ b/example/config.h
@@ -40,6 +40,4 @@ enum Parameters
     kParameterCount
 };
 
-#define CPLUG_NUM_PARAMS kParameterCount
-
 #endif // PLUGIN_CONFIG_H

--- a/example/example.c
+++ b/example/example.c
@@ -68,7 +68,7 @@ void sendParamEventFromMain(MyPlugin* plugin, uint32_t type, uint32_t paramIdx, 
 void cplug_libraryLoad(){};
 void cplug_libraryUnload(){};
 
-void* cplug_createPlugin()
+void* cplug_createPlugin(CplugHostContext* hostCtx)
 {
     MyPlugin* plugin = (MyPlugin*)malloc(sizeof(MyPlugin));
     memset(plugin, 0, sizeof(*plugin));
@@ -95,6 +95,11 @@ void cplug_destroyPlugin(void* ptr)
 {
     // Free any allocated resources in your plugin here
     free(ptr);
+}
+
+uint32_t cplug_getParamCount(CplugHostContext* hostCtx)
+{
+    return kParameterCount;
 }
 
 /* --------------------------------------------------------------------------------------------------------
@@ -133,7 +138,7 @@ const char* cplug_getOutputBusName(void* ptr, uint32_t idx)
 
 const char* cplug_getParameterName(void* ptr, uint32_t index)
 {
-    static const char* param_names[CPLUG_NUM_PARAMS] = {
+    static const char* param_names[kParameterCount] = {
         "Example Float Parameter",
         "Example Int Parameter",
         "Example Bool Parameter"};

--- a/example/example.c
+++ b/example/example.c
@@ -97,7 +97,7 @@ void cplug_destroyPlugin(void* ptr)
     free(ptr);
 }
 
-uint32_t cplug_getParamCount(CplugHostContext* hostCtx)
+uint32_t cplug_getParamCount(void* ptr)
 {
     return kParameterCount;
 }

--- a/src/cplug.h
+++ b/src/cplug.h
@@ -244,6 +244,7 @@ static inline int cplug_atomic_fetch_and_i32( cplug_atomic_i32* ptr, int v) { re
 #include <stdio.h>
 #define cplug_log(fmt, ...) fprintf(stderr, fmt "\n", __VA_ARGS__)
 #endif
+#endif
 
 #define CPLUG_LOG_ASSERT(cond)                                                                                         \
     if (unlikely(! (cond)))                                                                                            \

--- a/src/cplug.h
+++ b/src/cplug.h
@@ -42,9 +42,10 @@ extern "C" {
 CPLUG_API void cplug_libraryLoad();
 CPLUG_API void cplug_libraryUnload();
 
-CPLUG_API void* cplug_createPlugin();
+CPLUG_API void* cplug_createPlugin(void*);
 CPLUG_API void  cplug_destroyPlugin(void*);
 
+CPLUG_API uint32_t cplug_getParamCount(void*);
 CPLUG_API uint32_t cplug_getInputBusChannelCount(void*, uint32_t bus_idx);
 CPLUG_API uint32_t cplug_getOutputBusChannelCount(void*, uint32_t bus_idx);
 

--- a/src/cplug.h
+++ b/src/cplug.h
@@ -238,6 +238,9 @@ static inline int cplug_atomic_fetch_and_i32( cplug_atomic_i32* ptr, int v) { re
 #endif
 
 #ifndef cplug_log
+#if defined(NDEBUG)
+#define cplug_log(...)
+#else
 #include <stdio.h>
 #define cplug_log(fmt, ...) fprintf(stderr, fmt "\n", __VA_ARGS__)
 #endif

--- a/src/cplug.h
+++ b/src/cplug.h
@@ -237,22 +237,10 @@ static inline int cplug_atomic_fetch_and_i32( cplug_atomic_i32* ptr, int v) { re
 #define unlikely(x) x
 #endif
 
-#if defined(NDEBUG)
-#define cplug_log(...)
-#else
-#include <stdarg.h>
+#ifndef cplug_log
 #include <stdio.h>
-
-// When debugging in a host, consider adding: freopen(".../Desktop/log.txt", "a", stderr);
-static inline void cplug_log(const char* const fmt, ...)
-{
-    va_list args;
-    va_start(args, fmt);
-    vfprintf(stderr, fmt, args);
-    fprintf(stderr, "\n");
-    va_end(args);
-}
-#endif // NDEBUG
+#define cplug_log(fmt, ...) fprintf(stderr, fmt "\n", __VA_ARGS__)
+#endif
 
 #define CPLUG_LOG_ASSERT(cond)                                                                                         \
     if (unlikely(! (cond)))                                                                                            \

--- a/src/cplug.h
+++ b/src/cplug.h
@@ -245,7 +245,6 @@ static inline int cplug_atomic_fetch_and_i32( cplug_atomic_i32* ptr, int v) { re
 // When debugging in a host, consider adding: freopen(".../Desktop/log.txt", "a", stderr);
 static inline void cplug_log(const char* const fmt, ...)
 {
-    freopen("C:\\Users\\tredu\\Desktop\\log.txt", "a", stderr);
     va_list args;
     va_start(args, fmt);
     vfprintf(stderr, fmt, args);

--- a/src/cplug_auv2.c
+++ b/src/cplug_auv2.c
@@ -310,7 +310,7 @@ OSStatus AUMethodGetPropertyInfo(
     {
         // Global params only, else auval starts asking for input and output parameter detials
         CPLUG_LOG_ASSERT_RETURN(inScope == kAudioUnitScope_Global, kAudioUnitErr_InvalidScope);
-        CPLUG_SAFE_SET_PTR(outDataSize, sizeof(AudioUnitParameterID) * CPLUG_NUM_PARAMS);
+        CPLUG_SAFE_SET_PTR(outDataSize, sizeof(AudioUnitParameterID) * cplug_getParamCount(auv2));
         break;
     }
 
@@ -507,7 +507,7 @@ static OSStatus AUMethodGetProperty(
     case kAudioUnitProperty_ParameterList:
     {
         AudioUnitParameterID* paramList = (AudioUnitParameterID*)(outData);
-        for (UInt32 i = 0; i < CPLUG_NUM_PARAMS; i++)
+        for (UInt32 i = 0; i < cplug_getParamCount(auv2); i++)
             paramList[i] = i;
         break;
     }
@@ -931,7 +931,7 @@ static OSStatus AUMethodGetParameter(
     AudioUnitParameterValue* value)
 {
     // cplug_log("AUMethodGetParameter => %u %s %u %p", param, _cplugScope2Str(scope), elem, value);
-    CPLUG_LOG_ASSERT_RETURN(elem < CPLUG_NUM_PARAMS, kAudioUnitErr_InvalidParameter);
+    CPLUG_LOG_ASSERT_RETURN(elem < cplug_getParamCount(auv2), kAudioUnitErr_InvalidParameter);
     CPLUG_LOG_ASSERT_RETURN(auv2->userPlugin != NULL, kAudioUnitErr_Uninitialized);
     *value = (AudioUnitParameterValue)cplug_getParameterValue(auv2->userPlugin, param);
     return noErr;
@@ -948,7 +948,7 @@ static OSStatus AUMethodSetParameter(
 {
     // cplug_log("AUMethodSetParameter => %u %s %u %f %u", param, _cplugScope2Str(scope), elem, value, bufferOffset);
     CPLUG_LOG_ASSERT_RETURN(isfinite(value), kAudioUnitErr_InvalidParameter);
-    CPLUG_LOG_ASSERT_RETURN(param < CPLUG_NUM_PARAMS, kAudioUnitErr_InvalidParameter);
+    CPLUG_LOG_ASSERT_RETURN(param < cplug_getParamCount(auv2), kAudioUnitErr_InvalidParameter);
     CPLUG_LOG_ASSERT_RETURN(auv2->userPlugin != NULL, kAudioUnitErr_Uninitialized);
 
     if (! isfinite(value))
@@ -1295,7 +1295,7 @@ OSStatus ComponentBase_AP_Open(CplugHostContext* auv2, AudioComponentInstance co
 {
     cplug_log("ComponentBase_AP_Open");
     auv2->compInstance = compInstance;
-    auv2->userPlugin   = cplug_createPlugin();
+    auv2->userPlugin   = cplug_createPlugin(auv2);
     return auv2->userPlugin != NULL ? noErr : kAudioUnitErr_FailedInitialization;
 }
 

--- a/src/cplug_auv2.c
+++ b/src/cplug_auv2.c
@@ -310,7 +310,7 @@ OSStatus AUMethodGetPropertyInfo(
     {
         // Global params only, else auval starts asking for input and output parameter detials
         CPLUG_LOG_ASSERT_RETURN(inScope == kAudioUnitScope_Global, kAudioUnitErr_InvalidScope);
-        CPLUG_SAFE_SET_PTR(outDataSize, sizeof(AudioUnitParameterID) * cplug_getParamCount(auv2));
+        CPLUG_SAFE_SET_PTR(outDataSize, sizeof(AudioUnitParameterID) * cplug_getParamCount(auv2->userPlugin));
         break;
     }
 
@@ -507,7 +507,7 @@ static OSStatus AUMethodGetProperty(
     case kAudioUnitProperty_ParameterList:
     {
         AudioUnitParameterID* paramList = (AudioUnitParameterID*)(outData);
-        for (UInt32 i = 0; i < cplug_getParamCount(auv2); i++)
+        for (UInt32 i = 0; i < cplug_getParamCount(auv2->userPlugin); i++)
             paramList[i] = i;
         break;
     }
@@ -931,7 +931,7 @@ static OSStatus AUMethodGetParameter(
     AudioUnitParameterValue* value)
 {
     // cplug_log("AUMethodGetParameter => %u %s %u %p", param, _cplugScope2Str(scope), elem, value);
-    CPLUG_LOG_ASSERT_RETURN(elem < cplug_getParamCount(auv2), kAudioUnitErr_InvalidParameter);
+    CPLUG_LOG_ASSERT_RETURN(elem < cplug_getParamCount(auv2->userPlugin), kAudioUnitErr_InvalidParameter);
     CPLUG_LOG_ASSERT_RETURN(auv2->userPlugin != NULL, kAudioUnitErr_Uninitialized);
     *value = (AudioUnitParameterValue)cplug_getParameterValue(auv2->userPlugin, param);
     return noErr;
@@ -948,7 +948,7 @@ static OSStatus AUMethodSetParameter(
 {
     // cplug_log("AUMethodSetParameter => %u %s %u %f %u", param, _cplugScope2Str(scope), elem, value, bufferOffset);
     CPLUG_LOG_ASSERT_RETURN(isfinite(value), kAudioUnitErr_InvalidParameter);
-    CPLUG_LOG_ASSERT_RETURN(param < cplug_getParamCount(auv2), kAudioUnitErr_InvalidParameter);
+    CPLUG_LOG_ASSERT_RETURN(param < cplug_getParamCount(auv2->userPlugin), kAudioUnitErr_InvalidParameter);
     CPLUG_LOG_ASSERT_RETURN(auv2->userPlugin != NULL, kAudioUnitErr_Uninitialized);
 
     if (! isfinite(value))

--- a/src/cplug_clap.c
+++ b/src/cplug_clap.c
@@ -185,14 +185,14 @@ uint32_t CLAPExtParams_count(const clap_plugin_t* plugin)
 {
     cplug_log("CLAPExtParams_count");
     CplugHostContext* clap = (CplugHostContext*)plugin->plugin_data;
-    return cplug_getParamCount(clap);
+    return cplug_getParamCount(clap->userPlugin);
 }
 
 bool CLAPExtParams_get_info(const clap_plugin_t* plugin, uint32_t param_index, clap_param_info_t* param_info)
 {
     cplug_log("CLAPExtParams_get_info => %u %p", param_index, param_info);
     CplugHostContext* clap = (CplugHostContext*)plugin->plugin_data;
-    CPLUG_LOG_ASSERT_RETURN(param_index < cplug_getParamCount(clap), false);
+    CPLUG_LOG_ASSERT_RETURN(param_index < cplug_getParamCount(clap->userPlugin), false);
 
     param_info->id = param_index;
     snprintf(param_info->name, sizeof(param_info->name), "%s", cplug_getParameterName(clap->userPlugin, param_index));
@@ -223,7 +223,7 @@ bool CLAPExtParams_get_value(const clap_plugin_t* plugin, clap_id param_id, doub
 {
     cplug_log("CLAPExtParams_get_value => %u %p", param_id, out_value);
     CplugHostContext* clap = (CplugHostContext*)plugin->plugin_data;
-    CPLUG_LOG_ASSERT_RETURN(param_id < cplug_getParamCount(clap), false);
+    CPLUG_LOG_ASSERT_RETURN(param_id < cplug_getParamCount(clap->userPlugin), false);
     *out_value = cplug_getParameterValue(clap->userPlugin, param_id);
     return true;
 }
@@ -237,7 +237,7 @@ bool CLAPExtParams_value_to_text(
 {
     // cplug_log("CLAPExtParams_value_to_text => %u %f %p %u", param_id, value, out_buffer, out_buffer_capacity);
     CplugHostContext* clap = (CplugHostContext*)plugin->plugin_data;
-    CPLUG_LOG_ASSERT_RETURN(param_id < cplug_getParamCount(clap), false);
+    CPLUG_LOG_ASSERT_RETURN(param_id < cplug_getParamCount(clap->userPlugin), false);
 
     cplug_parameterValueToString(clap->userPlugin, param_id, out_buffer, out_buffer_capacity, value);
     return true;
@@ -251,7 +251,7 @@ bool CLAPExtParams_text_to_value(
 {
     cplug_log("CLAPExtParams_text_to_value => %u %p %p", param_id, param_value_text, out_value);
     CplugHostContext* clap = (CplugHostContext*)plugin->plugin_data;
-    CPLUG_LOG_ASSERT_RETURN(param_id < cplug_getParamCount(clap), false);
+    CPLUG_LOG_ASSERT_RETURN(param_id < cplug_getParamCount(clap->userPlugin), false);
     *out_value       = cplug_parameterStringToValue(clap->userPlugin, param_id, param_value_text);
     return true;
 }

--- a/src/cplug_standalone_osx.m
+++ b/src/cplug_standalone_osx.m
@@ -86,7 +86,7 @@ typedef struct CplugHostContext
 
     void (*libraryLoad)();
     void (*libraryUnload)();
-    void* (*createPlugin)();
+    void* (*createPlugin)(void*);
     void (*destroyPlugin)(void* userPlugin);
     uint32_t (*getOutputBusChannelCount)(void*, uint32_t bus_idx);
     void (*setSampleRateAndBlockSize)(void*, double sampleRate, uint32_t maxBlockSize);
@@ -1226,7 +1226,7 @@ void STAND_filesystemEventCallback(
             {
                 STAND_openLibraryWithSymbols();
                 g_plugin.libraryLoad();
-                g_plugin.userPlugin = g_plugin.createPlugin();
+                g_plugin.userPlugin = g_plugin.createPlugin(g_plugin);
                 cplug_assert(g_plugin.userPlugin != NULL);
                 g_plugin.loadState(g_plugin.userPlugin, &g_pluginState, STAND_readStateProc);
 

--- a/src/cplug_standalone_osx.m
+++ b/src/cplug_standalone_osx.m
@@ -78,7 +78,7 @@ enum MIDIMenuTag
 
 #pragma mark -Global state
 
-struct STAND_Plugin
+typedef struct CplugHostContext
 {
     void* library;
     void* userPlugin;
@@ -102,7 +102,9 @@ struct STAND_Plugin
     void (*getSize)(void* userGUI, uint32_t* width, uint32_t* height);
     void (*checkSize)(void* userGUI, uint32_t* width, uint32_t* height);
     bool (*setSize)(void* userGUI, uint32_t width, uint32_t height);
-} g_plugin;
+} CplugHostContext;
+
+CplugHostContext g_plugin;
 
 struct STAND_PluginStateContext
 {

--- a/src/cplug_standalone_win.c
+++ b/src/cplug_standalone_win.c
@@ -59,7 +59,7 @@ typedef struct CplugHostContext
 
     void (*libraryLoad)();
     void (*libraryUnload)();
-    void* (*createPlugin)();
+    void* (*createPlugin)(void*);
     void (*destroyPlugin)(void* userPlugin);
     uint32_t (*getOutputBusChannelCount)(void*, uint32_t bus_idx);
     void (*setSampleRateAndBlockSize)(void*, double sampleRate, uint32_t maxBlockSize);
@@ -291,7 +291,7 @@ int WINAPI WinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPSTR cmdline, int cmds
 
     CPWIN_LoadPlugin();
     _gCPLUG.libraryLoad();
-    _gCPLUG.userPlugin = _gCPLUG.createPlugin();
+    _gCPLUG.userPlugin = _gCPLUG.createPlugin(_gCPLUG);
     cplug_assert(_gCPLUG.userPlugin != NULL);
 
     ///////////////
@@ -625,7 +625,7 @@ LRESULT CALLBACK CPWIN_WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lP
             {
                 CPWIN_LoadPlugin();
                 _gCPLUG.libraryLoad();
-                _gCPLUG.userPlugin = _gCPLUG.createPlugin();
+                _gCPLUG.userPlugin = _gCPLUG.createPlugin(_gCPLUG);
                 cplug_assert(_gCPLUG.userPlugin != NULL);
                 _gCPLUG.loadState(_gCPLUG.userPlugin, &_gPluginState, CPWIN_ReadStateProc);
 

--- a/src/cplug_vst3.c
+++ b/src/cplug_vst3.c
@@ -769,7 +769,7 @@ static int32_t SMTG_STDMETHODCALLTYPE VST3Controller_getParameterCount(void* sel
 {
     // cplug_log("VST3Controller_getParameterCount => %p", self);
     CplugHostContext* const vst3 = _cplug_pointerShiftController((VST3Controller*)self);
-    return cplug_getParamCount(vst3);
+    return cplug_getParamCount(vst3->userPlugin);
 }
 
 static Steinberg_tresult SMTG_STDMETHODCALLTYPE
@@ -779,7 +779,7 @@ VST3Controller_getParameterInfo(void* self, int32_t index, struct Steinberg_Vst_
     CplugHostContext* const vst3 = _cplug_pointerShiftController((VST3Controller*)self);
 
     memset(info, 0, sizeof(*info));
-    CPLUG_LOG_ASSERT_RETURN(index >= 0 && index < cplug_getParamCount(vst3), Steinberg_kInvalidArgument);
+    CPLUG_LOG_ASSERT_RETURN(index >= 0 && index < cplug_getParamCount(vst3->userPlugin), Steinberg_kInvalidArgument);
     info->id = index;
 
     // set up flags
@@ -818,7 +818,7 @@ VST3Controller_getParamStringByValue(void* self, uint32_t index, double normalis
     CplugHostContext* const vst3 = _cplug_pointerShiftController((VST3Controller*)self);
     // Bitwig 5 has been spotted failing this assertion
     CPLUG_LOG_ASSERT_RETURN(normalised >= 0.0 && normalised <= 1.0, Steinberg_kInvalidArgument);
-    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3), Steinberg_kInvalidArgument);
+    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3->userPlugin), Steinberg_kInvalidArgument);
 
     char   buf[128];
     double denormalised = cplug_denormaliseParameterValue(vst3->userPlugin, index, normalised);
@@ -834,7 +834,7 @@ VST3Controller_getParamValueByString(void* self, uint32_t index, char16_t* input
     // cplug_log("VST3Controller_getParamValueByString => %p %u %p %p", self, rindex, input, output);
     CplugHostContext* const vst3 = _cplug_pointerShiftController((VST3Controller*)self);
 
-    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3), Steinberg_kInvalidArgument);
+    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3->userPlugin), Steinberg_kInvalidArgument);
 
     char as_utf8[128];
     _cplug_utf16To8(as_utf8, input, 128);
@@ -852,7 +852,7 @@ VST3Controller_normalizedParamToPlain(void* self, uint32_t index, double normali
     // cplug_log("VST3Controller_normalizedParamToPlain => %p %u %f", self, rindex, normalised);
     CplugHostContext* const vst3 = _cplug_pointerShiftController((VST3Controller*)self);
     CPLUG_LOG_ASSERT_RETURN(normalised >= 0.0 && normalised <= 1.0, 0.0);
-    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3), 0.0);
+    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3->userPlugin), 0.0);
 
     return cplug_denormaliseParameterValue(vst3->userPlugin, index, normalised);
 }
@@ -863,7 +863,7 @@ static double SMTG_STDMETHODCALLTYPE VST3Controller_plainParamToNormalised(void*
     // cplug_log("VST3Controller_plainParamToNormalised => %p %u %f", self, index, plain);
     CplugHostContext* const vst3 = _cplug_pointerShiftController((VST3Controller*)self);
 
-    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3), 0.0);
+    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3->userPlugin), 0.0);
 
     return cplug_normaliseParameterValue(vst3->userPlugin, index, plain);
 }
@@ -877,7 +877,7 @@ static double SMTG_STDMETHODCALLTYPE VST3Controller_getParamNormalized(void* sel
     if (index >= cplug_midiControllerOffset)
         return 0.0;
 
-    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3), 0.0);
+    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3->userPlugin), 0.0);
     double val = cplug_getParameterValue(vst3->userPlugin, index);
     return cplug_normaliseParameterValue(vst3->userPlugin, index, val);
 }
@@ -926,7 +926,7 @@ VST3Controller_setParamNormalized(void* const self, const uint32_t index, const 
         return Steinberg_kResultOk;
     }
 
-    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3), 0.0);
+    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3->userPlugin), 0.0);
     double denormalisedVal = cplug_denormaliseParameterValue(vst3->userPlugin, index, normalised);
     cplug_setParameterValue(vst3->userPlugin, index, denormalisedVal);
 

--- a/src/cplug_vst3.c
+++ b/src/cplug_vst3.c
@@ -768,7 +768,8 @@ VST3Controller_getState(void* const self, Steinberg_IBStream* const stream)
 static int32_t SMTG_STDMETHODCALLTYPE VST3Controller_getParameterCount(void* self)
 {
     // cplug_log("VST3Controller_getParameterCount => %p", self);
-    return CPLUG_NUM_PARAMS;
+    CplugHostContext* const vst3 = _cplug_pointerShiftController((VST3Controller*)self);
+    return cplug_getParamCount(vst3);
 }
 
 static Steinberg_tresult SMTG_STDMETHODCALLTYPE
@@ -778,7 +779,7 @@ VST3Controller_getParameterInfo(void* self, int32_t index, struct Steinberg_Vst_
     CplugHostContext* const vst3 = _cplug_pointerShiftController((VST3Controller*)self);
 
     memset(info, 0, sizeof(*info));
-    CPLUG_LOG_ASSERT_RETURN(index >= 0 && index < CPLUG_NUM_PARAMS, Steinberg_kInvalidArgument);
+    CPLUG_LOG_ASSERT_RETURN(index >= 0 && index < cplug_getParamCount(vst3), Steinberg_kInvalidArgument);
     info->id = index;
 
     // set up flags
@@ -817,7 +818,7 @@ VST3Controller_getParamStringByValue(void* self, uint32_t index, double normalis
     CplugHostContext* const vst3 = _cplug_pointerShiftController((VST3Controller*)self);
     // Bitwig 5 has been spotted failing this assertion
     CPLUG_LOG_ASSERT_RETURN(normalised >= 0.0 && normalised <= 1.0, Steinberg_kInvalidArgument);
-    CPLUG_LOG_ASSERT_RETURN(index < CPLUG_NUM_PARAMS, Steinberg_kInvalidArgument);
+    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3), Steinberg_kInvalidArgument);
 
     char   buf[128];
     double denormalised = cplug_denormaliseParameterValue(vst3->userPlugin, index, normalised);
@@ -833,7 +834,7 @@ VST3Controller_getParamValueByString(void* self, uint32_t index, char16_t* input
     // cplug_log("VST3Controller_getParamValueByString => %p %u %p %p", self, rindex, input, output);
     CplugHostContext* const vst3 = _cplug_pointerShiftController((VST3Controller*)self);
 
-    CPLUG_LOG_ASSERT_RETURN(index < CPLUG_NUM_PARAMS, Steinberg_kInvalidArgument);
+    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3), Steinberg_kInvalidArgument);
 
     char as_utf8[128];
     _cplug_utf16To8(as_utf8, input, 128);
@@ -851,7 +852,7 @@ VST3Controller_normalizedParamToPlain(void* self, uint32_t index, double normali
     // cplug_log("VST3Controller_normalizedParamToPlain => %p %u %f", self, rindex, normalised);
     CplugHostContext* const vst3 = _cplug_pointerShiftController((VST3Controller*)self);
     CPLUG_LOG_ASSERT_RETURN(normalised >= 0.0 && normalised <= 1.0, 0.0);
-    CPLUG_LOG_ASSERT_RETURN(index < CPLUG_NUM_PARAMS, 0.0);
+    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3), 0.0);
 
     return cplug_denormaliseParameterValue(vst3->userPlugin, index, normalised);
 }
@@ -862,7 +863,7 @@ static double SMTG_STDMETHODCALLTYPE VST3Controller_plainParamToNormalised(void*
     // cplug_log("VST3Controller_plainParamToNormalised => %p %u %f", self, index, plain);
     CplugHostContext* const vst3 = _cplug_pointerShiftController((VST3Controller*)self);
 
-    CPLUG_LOG_ASSERT_RETURN(index < CPLUG_NUM_PARAMS, 0.0);
+    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3), 0.0);
 
     return cplug_normaliseParameterValue(vst3->userPlugin, index, plain);
 }
@@ -876,7 +877,7 @@ static double SMTG_STDMETHODCALLTYPE VST3Controller_getParamNormalized(void* sel
     if (index >= cplug_midiControllerOffset)
         return 0.0;
 
-    CPLUG_LOG_ASSERT_RETURN(index < CPLUG_NUM_PARAMS, 0.0);
+    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3), 0.0);
     double val = cplug_getParameterValue(vst3->userPlugin, index);
     return cplug_normaliseParameterValue(vst3->userPlugin, index, val);
 }
@@ -925,7 +926,7 @@ VST3Controller_setParamNormalized(void* const self, const uint32_t index, const 
         return Steinberg_kResultOk;
     }
 
-    CPLUG_LOG_ASSERT_RETURN(index < CPLUG_NUM_PARAMS, 0.0);
+    CPLUG_LOG_ASSERT_RETURN(index < cplug_getParamCount(vst3), 0.0);
     double denormalisedVal = cplug_denormaliseParameterValue(vst3->userPlugin, index, normalised);
     cplug_setParameterValue(vst3->userPlugin, index, denormalisedVal);
 
@@ -1617,7 +1618,7 @@ VST3Component_initialize(void* const self, Steinberg_FUnknown* const context)
 
     cplug_log("VST3Component_initialize => %p %p | hostApplication %p", self, context, vst3->host);
 
-    vst3->userPlugin = cplug_createPlugin();
+    vst3->userPlugin = cplug_createPlugin(vst3);
 
     return Steinberg_kResultOk;
 }


### PR DESCRIPTION
I took the liberty of doing some of the changes we discussed. This includes using `CplugHostContext` everywhere instead of AUv2Plugin, CLAPPlugin and so on, removing `CPLUG_NUM_PARAMS` and calling `cplug_getParamCount()` instead, adding the host context pointer to `cplug_createPlugin()`. One bit of awkwardness is that I had to declare `cplug_createPlugin()` in `cplug.h` as taking a `void*` argument instead of `CplugHostContext*` due to `CplugHostContext` being declared later.

That takes care of the tedious part that had to be done before you can implement `propertyChanged()`.

I also changed `cplug_log()`, now it's defined by a macro, the idea is that if you don't define it it defaults to a `fprintf(stderr, ...)`, but if you do define it prior to `#include <cplug.h>` in your plugin then you can define it to a function in your plugin code much like the original `cplug_log()` function which can write to a file, for instance by doing `#define cplug_log myplugin_log`. Arguably it could be renamed to `CPLUG_LOG()` now that it's a macro, but I leave this choice up to you, I myself occasionally keep function alias macros as small caps because they call only functions.