### PR TITLE
fixing link to vst subcategories documentation

### DIFF
--- a/example/config.h
+++ b/example/config.h
@@ -17,7 +17,7 @@
 #define CPLUG_WANT_GUI 1
 #define CPLUG_GUI_RESIZABLE 1
 
-// See list of categories here: https://steinbergmedia.github.io/vst3_doc/vstinterfaces/group__plugType.html
+// See list of categories here: https://steinbergmedia.github.io/vst3_doc/vstinterfaces/namespaceSteinberg_1_1Vst_1_1PlugType.html
 #define CPLUG_VST3_CATEGORIES "Instrument|Stereo"
 
 #define CPLUG_VST3_TUID_COMPONENT 'cplg', 'comp', 'xmpl', 0


### PR DESCRIPTION
I was in the process of reading through the example code, and noticed the link to the subcategories documentation went to a seemingly broken or incomplete page. I found what I think is a non-broken page with similar info, although I'm not totally sure since I just started looking at this today. 