### PR TITLE
Multibyte char and non-C23 fixes

### DIFF
--- a/src/cplug.h
+++ b/src/cplug.h
@@ -19,6 +19,11 @@ extern "C" {
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifndef CPLUG_FOURCC
+#define CPLUG_FOURCC(a, b, c, d) \
+    ((((uint32_t)(uint8_t)(a)) << 24) | (((uint32_t)(uint8_t)(b)) << 16) | (((uint32_t)(uint8_t)(c)) << 8) | ((uint32_t)(uint8_t)(d)))
+#endif
+
 #ifdef CPLUG_SHARED
 #ifdef _WIN32
 #define CPLUG_API __declspec(dllexport)
@@ -226,7 +231,7 @@ CPLUG_API void cplug_loadState(void* userPlugin, const void* stateCtx, cplug_rea
 // AUv2 hacks. Unfortunately Apple's API designs are offensive leaky abstractions.
 enum
 {
-    kAudioUnitProperty_AUV2Wrapper    = 'plug',
+    kAudioUnitProperty_AUV2Wrapper    = CPLUG_FOURCC('p', 'l', 'u', 'g'),
     CPLUG_AUV2_OFFSET_WRAPPER_CONTEXT = 64,
     CPLUG_AUV2_OFFSET_PLUGIN          = CPLUG_AUV2_OFFSET_WRAPPER_CONTEXT + sizeof(CplugHostContext),
     CPLUG_AUV2_OFFSET_NSVIEW          = CPLUG_AUV2_OFFSET_PLUGIN + sizeof(size_t),

--- a/src/cplug_extensions/window_win.c
+++ b/src/cplug_extensions/window_win.c
@@ -557,7 +557,7 @@ void pw_set_mouse_cursor(void* _pw, enum PWCursorType type)
         cursor = LoadCursorW(NULL, (LPCWSTR)IDC_HAND);
         break;
     case PW_CURSOR_HAND_DRAGGABLE:
-        // clang-format off
+        ;// clang-format off
         static const uint8_t OPEN_HAND_AND_MASK[] = {
             0xFE, 0x7F, 0xE4, 0x0F, 0xC0, 0x07, 0xC0, 0x05,
             0xE0, 0x00, 0xE0, 0x00, 0x90, 0x00, 0x00, 0x00,
@@ -578,7 +578,7 @@ void pw_set_mouse_cursor(void* _pw, enum PWCursorType type)
         cursor = pw->hCursorOpenHand;
         break;
     case PW_CURSOR_HAND_DRAGGING:
-        // clang-format off
+        ;// clang-format off
         static const uint8_t CLOSED_HAND_AND_MASK[] = {
             0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xF2, 0x4F,
             0xE0, 0x03, 0xE0, 0x01, 0xF0, 0x01, 0xE0, 0x01,

--- a/src/cplug_standalone_win.c
+++ b/src/cplug_standalone_win.c
@@ -373,8 +373,8 @@ void Cplug_DuplicatePatchAndLoadDll()
 
         enum
         {
-            PDB2_SIGNATURE = '01BN',
-            PDB7_SIGNATURE = 'SDSR',
+            PDB2_SIGNATURE = CPLUG_FOURCC('0', '1', 'B', 'N'),
+            PDB7_SIGNATURE = CPLUG_FOURCC('S', 'D', 'S', 'R'),
         };
         struct CV_INFO_PDB70
         {


### PR DESCRIPTION
I found some warnings when testing with different compilers. Declaring a variable after a case label isn't valid in pre-C23 so I added semi-colons where that happened. and GCC complained about multi-character character constants.